### PR TITLE
_.concat is not supported in Lodash 3.10

### DIFF
--- a/creep.behaviour.worker.js
+++ b/creep.behaviour.worker.js
@@ -59,7 +59,7 @@ module.exports = {
                     Creep.action.upgrading, 
                     Creep.action.idle];
             if( creep.room.ticksToDowngrade < 2000 ) { // urgent upgrading 
-                priority.unshift(Creep.action.storing);
+                priority.unshift(Creep.action.upgrading);
                 //priority = _.concat(Creep.action.upgrading, priority);
             }
         }

--- a/creep.behaviour.worker.js
+++ b/creep.behaviour.worker.js
@@ -34,7 +34,8 @@ module.exports = {
                     //Creep.action.withdrawing, 
                     Creep.action.idle];       
             if( _.sum(creep.carry) > creep.carry.energy ) {
-                priority = _.concat(Creep.action.storing, priority);
+                priority.unshift(Creep.action.storing);
+                //priority = _.concat(Creep.action.storing, priority);
             }
         }    
         else {	  
@@ -58,7 +59,8 @@ module.exports = {
                     Creep.action.upgrading, 
                     Creep.action.idle];
             if( creep.room.ticksToDowngrade < 2000 ) { // urgent upgrading 
-                priority = _.concat(Creep.action.upgrading, priority);
+                priority.unshift(Creep.action.storing);
+                //priority = _.concat(Creep.action.upgrading, priority);
             }
         }
         for(var iAction = 0; iAction < priority.length; iAction++) {


### PR DESCRIPTION
_.concat is not supported  in Lodash 3.10, which screeps uses. 
(PTR server is an exception on this)