### PR TITLE
Add reserve action for claimers

### DIFF
--- a/creep.action.reserving.js
+++ b/creep.action.reserving.js
@@ -1,11 +1,11 @@
-var action = new Creep.Action('claiming');
+var action = new Creep.Action('reserving');
 action.reusePath = 10;
 action.isValidAction = function(creep){ return true; }; 
 action.isValidTarget = function(target){ return true; }; 
 action.isAddableAction = function(){ return true; };
 action.isAddableTarget = function(){ return true; }; 
 action.newTarget = function(creep){
-    let flag = FlagDir.find(FLAG_COLOR.claim, creep.pos, false, FlagDir.rangeMod);
+    let flag = FlagDir.find(FLAG_COLOR.reserve, creep.pos, false, FlagDir.rangeMod);
     if( flag ) { 
         Population.registerCreepFlag(creep, flag);
     } 
@@ -15,7 +15,7 @@ action.newTarget = function(creep){
     if( !creep.flag.room || creep.flag.pos.roomName != creep.pos.roomName){
         return creep.flag;    
     }
-    if( creep.flag.room.controller.my ) { // TODO: AND is claim flag 
+    if( creep.flag.room.controller.my ) { // TODO: AND is reserve flag
         // already claimed, change flag
         // TODO: only if no spawn or spawn-constructionSite present
         creep.flag.setColor(FLAG_COLOR.claim.spawn.color, FLAG_COLOR.claim.spawn.secondaryColor);
@@ -57,10 +57,7 @@ action.work = function(creep){
         workResult = creep.attackController(creep.target);
     }
     else {
-        workResult = creep.claimController(creep.target);
-        if( workResult != OK ){
-            workResult = creep.reserveController(creep.target);
-        }
+        workResult = creep.reserveController(creep.target);
     }
     return workResult;
 };

--- a/creep.behaviour.claimer.js
+++ b/creep.behaviour.claimer.js
@@ -19,7 +19,8 @@ module.exports = {
     },
     nextAction: function(creep){ 
         let priority = [
-            Creep.action.claiming, 
+            Creep.action.claiming,
+            Creep.action.reserving,
             Creep.action.idle
         ];
         for(var iAction = 0; iAction < priority.length; iAction++) {

--- a/creep.js
+++ b/creep.js
@@ -5,7 +5,8 @@ var mod = {
         Creep.action = {
             building: require('./creep.action.building'), 
             charging: require('./creep.action.charging'),
-            claiming: require('./creep.action.claiming'), 
+            claiming: require('./creep.action.claiming'),
+            reserving: require('./creep.action.reserving'),
             defending: require('./creep.action.defending'),
             feeding: require('./creep.action.feeding'), 
             fueling: require('./creep.action.fueling'), 

--- a/creep.setup.claimer.js
+++ b/creep.setup.claimer.js
@@ -5,13 +5,13 @@ setup.minAbsEnergyAvailable = 1300;
 setup.maxMulti = 0;
 setup.minControllerLevel = 3;
 setup.globalMeasurement = true;
-setup.sortedParts = false;
+setup.sortedParts = true;
 setup.minEnergyAvailable = function(spawn){
     return 0.75;
 }
 setup.maxCount = function(spawn){
     return _.filter(Game.flags, function(flag){
-        return flag.color == FLAG_COLOR.claim.color && flag.secondaryColor == FLAG_COLOR.claim.secondaryColor && 
+        return ((flag.color == FLAG_COLOR.claim.color && flag.secondaryColor == FLAG_COLOR.claim.secondaryColor) || (flag.color == FLAG_COLOR.reserve.color && flag.secondaryColor == FLAG_COLOR.reserve.secondaryColor)) &&
             (!flag.room || 
             (!flag.room.controller || !flag.room.controller.reservation) || 
             flag.room.controller.reservation.ticksToEnd < 4000)}).length;

--- a/global.js
+++ b/global.js
@@ -39,7 +39,11 @@ var mod = {
                     filter: {'color': COLOR_ORANGE, 'secondaryColor': COLOR_ORANGE }
                 },
                 //COLOR_BROWN,
-                // COLOR_GREY,
+                reserve: { // reserve this room
+                    color: COLOR_GREY,
+                    secondaryColor: COLOR_GREY,
+                    filter: {'color': COLOR_GREY, 'secondaryColor': COLOR_GREY },
+                },
                 claim: { // claim this room
                     color: COLOR_WHITE, 
                     secondaryColor: COLOR_WHITE,


### PR DESCRIPTION
Allow claimers to reserve rooms without claiming them using a grey flag. Lower priority than the claiming action.