### PR TITLE
RCL 2&3 haulers will drop at spawn and not move around work parts

### DIFF
--- a/creep.behaviour.hauler.js
+++ b/creep.behaviour.hauler.js
@@ -35,6 +35,7 @@ mod.nextAction = function(creep){
             Creep.action.charging,
             Creep.action.fueling,
             Creep.action.storing,
+            Creep.action.dropping,
             Creep.action.idle];
 
         if ( creep.sum > creep.carry.energy ||

--- a/creep.setup.hauler.js
+++ b/creep.setup.hauler.js
@@ -49,10 +49,19 @@ setup.default = {
     maxCount: setup.maxCount,
     maxWeight: setup.maxWeight
 };
+setup.low = {
+    fixedBody: [CARRY, CARRY, MOVE],
+    multiBody: [CARRY, CARRY, MOVE],
+    minAbsEnergyAvailable: 150,
+    minEnergyAvailable: 0.4,
+    maxMulti: setup.maxMulti,
+    maxCount: setup.maxCount,
+    maxWeight: setup.maxWeight
+};
 setup.RCL = {
     1: setup.none,
-    2: setup.default,
-    3: setup.default,
+    2: setup.low,
+    3: setup.low,
     4: setup.default,
     5: setup.default,
     6: setup.default,


### PR DESCRIPTION
another respawn tweak, also adds the dropping action to in-room haulers