### PR TITLE
[WIP] Mobile Storage Creep

### DIFF
--- a/creep.action.delivering.js
+++ b/creep.action.delivering.js
@@ -1,0 +1,3 @@
+/**
+ * Created by Admin on 2017-03-11.
+ */

--- a/creep.action.storage.js
+++ b/creep.action.storage.js
@@ -1,0 +1,3 @@
+/**
+ * Created by Admin on 2017-03-11.
+ */

--- a/creep.action.storage.js
+++ b/creep.action.storage.js
@@ -1,3 +1,28 @@
-/**
- * Created by Admin on 2017-03-11.
- */
+const action = new Creep.Action('storage');
+module.exports = action;
+action.isAddableAction = function(){ return true; };
+action.isAddableTarget = function(){ return true; };
+action.reachedRange = 0;
+action.newTarget = function(creep){
+    let flag;
+    if( creep.data.destiny ) flag = Game.flags[creep.data.destiny.flagName];
+    if ( !flag ) {
+        flag = FlagDir.find(FLAG_COLOR.economy, creep.pos, false, FlagDir.rangeMod, {
+            rangeModPerCrowd: 400
+            //rangeModByType: creep.data.creepType
+        });
+    }
+    
+    if( creep.action && creep.action.name == 'storage' && creep.flag )
+        return creep.flag;
+    if( flag ) Population.registerCreepFlag(creep, flag);
+    return flag;
+};
+action.work = function(creep){
+    if( creep.data.flagName )
+        return OK;
+    else return ERR_INVALID_ARGS;
+};
+action.onAssignment = function(creep, target) {
+    if( SAY_ASSIGNMENT ) creep.say(String.fromCodePoint(0x1F6E2), SAY_PUBLIC);
+};

--- a/creep.behaviour.mobileStorage.js
+++ b/creep.behaviour.mobileStorage.js
@@ -1,0 +1,30 @@
+module.exports = {
+    name: 'mobileStorage',
+    actionPriority: [
+        Creep.action.delivering,
+        Creep.action.storage,
+        Creep.action.idle,
+    ],
+    run(creep) {
+        if (!creep.action || creep.action.name === 'idle' ||
+            (creep.action.name === 'storage' && (!creep.flag || creep.flag.pos.roomName === creep.pos.roomName || creep.leaveBorder()))) {
+            this.nextAction(creep);
+        }
+        
+        if (creep.action && creep.target) {
+            creep.action.step(creep);
+        } else {
+            logError(`Creep without action/activity!\nCreep: ${creep.name}\ndata: ${JSON.stringify(creep.data)}`);
+        }
+    },
+    nextAction(creep) {
+        for (let action of this.actionPriority) {
+            if (action.isValidAction(creep) &&
+                action.isAddableAction(creep) &&
+                action.assign(creep)) {
+                return;
+            }
+        }
+    },
+    
+};

--- a/global.js
+++ b/global.js
@@ -62,6 +62,10 @@ mod.FLAG_COLOR = {
         }
     },
     //COLOR_PURPLE,
+    economy: {
+        color: COLOR_PURPLE,
+        secondaryColor: COLOR_PURPLE,
+    },
     //COLOR_BLUE,
     //COLOR_CYAN - Reserved
     //COLOR_GREEN

--- a/task.mobileStorage.js
+++ b/task.mobileStorage.js
@@ -1,0 +1,141 @@
+const mod = {};
+module.exports = mod;
+
+mod.register = () => {
+    Flag.found.on(Task.mobileStorage.handleFlagFound);
+    
+    Creep.spawningStarted.on(Task.mobileStorage.handleSpawningStarted);
+    
+    Creep.spawningCompleted.on(Task.mobileStorage.handleSpawningCompleted);
+    
+    Creep.predictedRenewal.on(creep => Task.mobileStorage.handleCreepDied(creep.name));
+    
+    Creep.died.on(Task.mobileStorage.handleCreepDied);
+};
+
+mod.handleFlagFound = flag => {
+    if (flag.color === FLAG_COLOR.economy.color && flag.secondaryColor === FLAG_COLOR.economy.secondaryColor) {
+        Task.mobileStorage.checks(flag);
+    }
+};
+
+mod.checks = flag => {
+    if (!flag || !flag.room) return;
+    
+    const memory = Task.mobileStorage.memory(flag);
+    
+    const count = memory.queued.length + memory.spawning.length + memory.running.length;
+    
+    if (count < 1) {
+        Task.spawn(
+            Task.mobileStorage.creep,
+            {
+                task: 'mobileStorage',
+                targetName: flag.name,
+                flagName: flag.name,
+            },
+            {
+                targetRoom: flag.pos.roomName,
+                minEnergyCapacity: 1050,
+                rangeRclRatio: 2,
+            },
+            creepSetup => {
+                const memory = Task.mobileStorage.memory(Game.flags[creepSetup.destiny.targetName]);
+                memory.queued.push({
+                    room: creepSetup.queueRoom,
+                    name: creepSetup.name,
+                    targetName: flag.name,
+                });
+            }
+        );
+    }
+};
+
+mod.handleSpawningStarted = params => {
+    if (!params.destiny || !params.destiny.task || params.destiny.task !== 'mobileStorage') return;
+    
+    const flag = Game.flags[params.destiny.flagName];
+    if (flag) {
+        const memory = Task.mobileStorage.memory.flag(flag);
+        memory.spawning.push(params);
+        const queued = [];
+        const validateQueued = o => {
+            const room = Game.rooms[o.room];
+            if (room.spawnQueueLow.some(c => c.name === o.name)) {
+                queued.push(o);
+            }
+        };
+        memory.queued.forEach(validateQueued);
+        memory.queued = queued;
+    }
+};
+
+mod.handleSpawningCompleted = creep => {
+    if (!creep.data || !creep.data.destiny || !creep.data.destiny.task || creep.data.destiny.task !== 'mobileStorage') return;
+    
+    const flag = Game.flags[creep.data.destiny.flagName];
+    if (flag) {
+        creep.data.predictedRenewal = creep.data.spawningTime + routeRange(creep.data.homeRoom, flag.pos.roomName) * 50;
+        
+        const memory = Task.mobileStorage.memory(flag);
+        memory.running.push(creep.name);
+        
+        const spawning = [];
+        const validateSpawning = o => {
+            const spawn = Game.spawns[o.spawn];
+            if (spawn && (spawn.spawning && spawn.spawning.name === o.name || spawn.newSpawn && spawn.newSpawn.name === o.name)) {
+                spawning.push(o);
+            }
+        };
+        memory.spawning.forEach(validateSpawning);
+        memory.spawning = spawning;
+    }
+};
+
+mod.handleCreepDied = name => {
+    const mem = Memory.population[name];
+    if (!mem || !mem.destiny || !mem.destiny.task || mem.destiny.task !== 'mobileStorage') return;
+    
+    const flag = Game.flags[mem.destiny.flagName];
+    if (flag) {
+        const memory = Task.mobileStorage.memory(flag);
+        const running = [];
+        const validateRunning = o => {
+            const creep = Game.creeps[o];
+            if (!creep || !creep.data) return;
+            let prediction;
+            if (creep.data.predictedRenewal) {
+                prediction = creep.data.predictedRenewal;
+            } else if (creep.data.spawningTime) {
+                prediction = creep.data.spawningtime + (routeRange(creep.data.homeRoom, flag.pos.roomName) * 50);
+            } else {
+                prediction = (routeRange(creep.data.homeRoom, flag.pos.roomName) + 1) * 50;
+            }
+            if (creep.name !== name && creep.ticksToLive > prediction) {
+                running.push(o);
+            }
+        };
+        memory.running.forEach(validateRunning);
+        memory.running = running;
+    }
+};
+
+mod.memory = flag => {
+    if (!flag.memory.tasks) flag.memory.tasks = {};
+    if (!flag.memory.tasks.mobileStorage) {
+        flag.memory.tasks.mobileStorage = {
+            queued: [],
+            spawning: [],
+            running: [],
+        };
+    }
+    return flag.memory.tasks.mobileStorage;
+};
+
+mod.creep = {
+    fixedBody: [CARRY,CARRY,CARRY,CARRY,CARRY,CARRY,CARRY,CARRY,CARRY,CARRY,CARRY,CARRY,CARRY,CARRY,MOVE,MOVE,MOVE,MOVE,MOVE,MOVE,MOVE],
+    multiBody: [CARRY,CARRY,MOVE],
+    name: 'mobileStorage',
+    behaviour: 'mobileStorage',
+    queue: 'Low',
+};


### PR DESCRIPTION
Mobile Storage Creep. Currently a WIP.

Waiting for the viral tasks PR to get merged so I can add this task to the list.

TODO:

 - Delivering Action: A creep will request a resource, and the mobile storage will move to that creep and transfer to it. Ideally, taking the distance into account.
 - Storage Action: Similar to guarding action. Idles at the flag placed.
 - Add Mobile Storage as a valid target to reallocate energy.