### PR TITLE
Classify Tasks

### DIFF
--- a/main.js
+++ b/main.js
@@ -216,7 +216,7 @@ global.install = () => {
     Room.extend();
     Spawn.extend();
     FlagDir.extend();
-    Task.populate();
+    Task.extend();
     // custom extend
     if( global.mainInjection.extend ) global.mainInjection.extend();
     if (DEBUG) logSystem('Global.install', 'Code reloaded.');

--- a/task.attackController.js
+++ b/task.attackController.js
@@ -1,8 +1,6 @@
 // This task will react on Red/Cyan flags, sending a giant (RCL7 Req) claiming creep to the flags position.
-let mod = {};
+let mod = new Task('attackController');
 module.exports = mod;
-// hook into events
-mod.register = () => {};
 // for each flag
 mod.handleFlagFound = flag => {
     // if it is a Green/Purple flag

--- a/task.claim.js
+++ b/task.claim.js
@@ -1,9 +1,7 @@
 // This task will react on claim flags (Green/Green), sending a claiming creep to the flags position.
-let mod = {};
+let mod = new Task('claim');
 module.exports = mod; 
 mod.minControllerLevel = 3;
-// hook into events
-mod.register = () => {};
 // for each flag
 mod.handleFlagFound = flag => {
     // if it is a yellow/yellow flag

--- a/task.defense.js
+++ b/task.defense.js
@@ -1,8 +1,6 @@
 // Defense task handles spotted invaders. Spawns defenders and gives them special behaviour.
-let mod = {};
+let mod = new Task('defense');
 module.exports = mod;
-// hook into events
-mod.register = () => {};
 // When a new invader has been spotted
 mod.handleNewInvader = invaderCreep => {
     // ignore if on blacklist

--- a/task.guard.js
+++ b/task.guard.js
@@ -1,9 +1,7 @@
 // This task will react on yellow/yellow flags, sending a guarding creep to the flags position.
-let mod = {};
+let mod = new Task('guard');
 module.exports = mod;
 mod.minControllerLevel = 3;
-// hook into events
-mod.register = () => {};
 // for each flag
 mod.handleFlagFound = flag => {
     // if it is a yellow/yellow flag

--- a/task.js
+++ b/task.js
@@ -1,5 +1,5 @@
 const Task = class {
-    constructor(...args) {
+    constructor(...args) { // Allows constructor to be extended
         Task.prototype.constructor.apply(this, args);
     }
 };
@@ -8,15 +8,26 @@ module.exports = Task;
 const cache = {};
 
 Task.extend = function() {
+    // STATIC
     Object.defineProperties(Task, {
         tasks: {
             configurable: true,
-            value: [],
+            value: [
+                Task.attackController,
+                Task.claim,
+                Task.defense,
+                Task.guard,
+                Task.mining,
+                Task.pioneer,
+                Task.reputation,
+                Task.reserve,
+                Task.robbing,
+            ],
         },
         installTask: {
             value: function(...taskNames) {
                 taskNames.forEach(taskName => {
-                    Task[taskName] = load(`task.${taskName}`);
+                    Task[taskName] = Task[taskName] || load(`task.${taskName}`);
                     new Task(Task[taskName]);
                 });
             },
@@ -24,10 +35,7 @@ Task.extend = function() {
         memory: {
             configurable: true,
             value: function(task, s) {
-                if (!Memory.tasks) Memory.tasks = {};
-                if (!Memory.tasks[task]) Memory.tasks[task] = {};
-                if (!Memory.tasks[task][s]) Memory.tasks[task][s] = {};
-                return Memory.tasks[task][s];
+                return Util.get(Memory, `tasks.${task}.${s}`, {});
             },
         },
         clearMemory: {
@@ -39,9 +47,7 @@ Task.extend = function() {
         cache: {
             configurable: true,
             value: function(task, s) {
-                if (!cache[task]) cache[task] = {};
-                if (!cache[task][s]) cache[task][s] = {};
-                return cache[task][s];
+                return Util.get(cache, `${task}.${s}`, {});
             },
         },
         clearCache: {
@@ -83,10 +89,42 @@ Task.extend = function() {
         },
     });
     
+    // INSTANCE
     Task.prototype.constructor = function(task) {
-        if (!(task instanceof Task)) Task.installTask(task);
+        if (!(task instanceof Task)) {  // not a task
+            Task.installTask(task);     // install the task
+            return;                     // and return
+        }
         Task.tasks.push(task);
-    }
+    };
+    
+    Task.prototype.register = function() {
+        if (this.handleFlagFound) Flag.found.on(flag => this.handleFlagFound(flag));
+        if (this.handleFlagRemoved) Flag.FlagRemoved.on(flagName => this.handleFlagRemoved(flagName));
+        
+        if (this.handleSpawningStarted) Creep.spawningStarted.on(params => this.handleSpawningStarted(params));
+        if (this.handleSpawningCompleted) Creep.spawningCompleted.on(creep => this.handleSpawningCompleted(creep));
+        if (this.handleCreepDied) {
+            Creep.predictedRenewal.on(creep => this.handleCreepDied(creep.name));
+            Creep.died.on(name => this.handleCreepDied(name));
+        }
+        if (this.handleCreepError) Creep.error.on(errorData => this.handleCreepError(errorData));
+        
+        if (this.handleNewInvader) Room.newInvader.on(invader => this.handleNewInvader(invader));
+        if (this.handleKnownInvader) Room.knownInvader.on(invaderID => this.handleKnownInvader(invaderID));
+        if (this.handleGoneInvader) Room.goneInvader.on(invaderID => this.handleGoneInvader(invaderID));
+        if (this.handleRoomDied) Room.collapsed.on(room => this.handleRoomDied(room));
+    };
+    
+    Task.prototype.handleFlagRemoved = function(flagName) {
+        const flagMem = Memory.flags[flagName];
+        if (flagMem && flagMem.task === this.name && flagMem.roomName) {
+            const flags = FlagDir.filter(FLAG_COLOR.claim.mining, new RoomPosition(25, 25, flagMem.roomName), true);
+            if (!(flags && flags.length > 0)) {
+                Task.clearMemory(this.name, flagMem.roomName);
+            }
+        }
+    };
 };
 // load task memory & flush caches
 Task.flush = function () {
@@ -94,28 +132,9 @@ Task.flush = function () {
         if (task.flush) task.flush();
     });
 };
-// temporary hack to avoid registering twice internally, remove and fix internal when merged.
-mod.selfRegister = true;
 // register tasks (hook up into events)
 Task.register = function () {
     Task.tasks.forEach(task => {
-        // Extending of any other kind
-        if (task.register) task.register();
-        // Flag Events
-        if (task.handleFlagFound) Flag.found.on(flag => task.handleFlagFound(flag));
-        if (task.handleFlagRemoved) Flag.FlagRemoved.on(flagName => task.handleFlagRemoved(flagName));
-        // Creep Events
-        if (task.handleSpawningStarted) Creep.spawningStarted.on(params => task.handleSpawningStarted(params));
-        if (task.handleSpawningCompleted) Creep.spawningCompleted.on(creep => task.handleSpawningCompleted(creep));
-        if (task.handleCreepDied) {
-            Creep.predictedRenewal.on(creep => task.handleCreepDied(creep.name));
-            Creep.died.on(name => task.handleCreepDied(name));
-        }
-        if (task.handleCreepError) Creep.error.on(errorData => task.handleCreepError(errorData));
-        // Room events
-        if (task.handleNewInvader) Room.newInvader.on(invader => task.handleNewInvader(invader));
-        if (task.handleKnownInvader) Room.knownInvader.on(invaderID => task.handleKnownInvader(invaderID));
-        if (task.handleGoneInvader) Room.goneInvader.on(invaderID => task.handleGoneInvader(invaderID));
-        if (task.handleRoomDied) Room.collapsed.on(room => task.handleRoomDied(room));
+        task.register();
     });
 };

--- a/task.js
+++ b/task.js
@@ -91,9 +91,9 @@ Task.extend = function() {
     
     // INSTANCE
     Task.prototype.constructor = function(task) {
-        if (!(task instanceof Task)) {  // not a task
-            Task.installTask(task);     // install the task
-            return;                     // and return
+        if (task.link) {            // not a task
+            Task.installTask(task); // install the task
+            return;                 // and return
         }
         Task.tasks.push(task);
     };

--- a/task.mining.js
+++ b/task.mining.js
@@ -1,8 +1,7 @@
-const mod = {};
+const mod = new Task('mining');
 module.exports = mod;
 mod.minControllerLevel = 2;
 mod.name = 'mining';
-mod.register = () => {};
 mod.checkFlag = (flag) => {
     if( flag.color == FLAG_COLOR.claim.mining.color && flag.secondaryColor == FLAG_COLOR.claim.mining.secondaryColor ) {
         flag.memory.roomName = flag.pos.roomName;
@@ -10,21 +9,6 @@ mod.checkFlag = (flag) => {
         return true;
     }
     return false;
-};
-mod.handleFlagRemoved = flagName => {
-    // check flag
-    const flagMem = Memory.flags[flagName];
-    if( flagMem && flagMem.task === mod.name && flagMem.roomName ){
-        // if there is still a mining flag in that room ignore. 
-        const flags = FlagDir.filter(FLAG_COLOR.claim.mining, new RoomPosition(25,25,flagMem.roomName), true);
-        if( flags && flags.length > 0 ) 
-            return;
-        else {
-            // no more mining in that room. 
-            // clear memory
-            Task.clearMemory(mod.name, flagMem.roomName);
-        }
-    }
 };
 mod.handleFlagFound = flag => {
     // Analyze Flag

--- a/task.pioneer.js
+++ b/task.pioneer.js
@@ -1,8 +1,6 @@
 // This task will react on pioneer flags - 4 for Green/White, 1 for Green/Red
-let mod = {};
+let mod = new Task('pioneer');
 module.exports = mod;
-// hook into events
-mod.register = () => {};
 mod.handleRoomDied = room => {
     // try to spawn a worker
     let pioneer = true;

--- a/task.reputation.js
+++ b/task.reputation.js
@@ -1,3 +1,100 @@
+const mod = new Task('reputation');
+module.exports = mod;
+
+mod.name = 'reputation';
+mod.myName = () => _.chain(Game.rooms).map('controller').flatten().filter('my').map('owner.username').first().value();
+mod.isNPC = username => NPC[username] === true;
+mod.npcOwner = creep => creep.owner && mod.isNPC(creep.owner.username);
+mod.isAlly = username => mod.score(username) >= CONST.ALLY;
+mod.notAlly = username => !mod.isAlly(username);
+mod.allyOwner = creep => creep.owner && mod.isAlly(creep.owner.username);
+mod.isHostile = username => mod.score(username) < CONST.NEUTRAL;
+mod.notHostile = username => !mod.isHostile(username);
+mod.hostileOwner = creep => creep.owner && mod.isHostile(creep.owner.username);
+mod.whitelist = () => mod.cache('whitelist');
+mod.score = username => {
+    const reps = mod.cache('score');
+    if( username === undefined ) {
+        return reps;
+    }
+    const name = username && username.toLowerCase();
+    if( reps[name] ) {
+        return reps[name];
+    } else {
+        return reps[name] = 0;
+    }
+};
+mod.setScore = (username, score) => {
+    const name = username && username.toLowerCase();
+    mod.score()[name] = score;
+    mod.playerMemory(name).score = score;
+};
+
+mod.flush = () => {
+    mod._loadWhitelist();
+    mod._loadScore();
+};
+mod.cache = table => Task.cache(mod.name, table);
+mod.killScoreCache = () => {
+    Task.clearCache(mod.name, 'score');
+    return mod.score();
+};
+mod.killWhitelistCache = () => {
+    Task.clearCache(mod.name, 'score');
+    Task.clearCache(mod.name, 'whitelist');
+    return mod.whitelist();
+};
+mod.memory = table => Task.memory(mod.name, table);
+mod.playerMemory = username => {
+    const playerMemory = mod.memory('players');
+    const name = username && username.toLowerCase();
+    if( playerMemory[name] ) {
+        return playerMemory[name];
+    } else {
+        return playerMemory[name] = {};
+    }
+};
+
+mod._loadScore = () => {
+    const etc = mod.cache('etc');
+    const playerMemory = mod.memory('players');
+    const whitelist = mod.whitelist();
+    let score = mod.score();
+    if( _.keys(playerMemory).length + _.keys(whitelist).length
+            !== _.keys(score).length + etc.whitelistRepUnion) {
+        score = mod.killScoreCache();
+        for( const n in NPC ) {
+            score[n] = CONST.NPC_SCORE;
+        }
+        _.keys(whitelist).forEach(function(player) {
+            score[player] = CONST.WHITELIST_SCORE;
+        });
+
+        etc.whitelistRepUnion = 0;
+        _.reduce(playerMemory, function(list, player, name) {
+            if( typeof player.score === "number" ) {
+                if( whitelist[name] ) {
+                    etc.whitelistRepUnion++;
+                }
+                list[name] = player.score;
+            }
+            return list;
+        }, score);
+
+        mod.setScore(mod.myName(), CONST.MY_SCORE);
+    }
+};
+mod._loadWhitelist = () => {
+    let whitelist = mod.whitelist();
+    if( _.keys(whitelist).length !== PLAYER_WHITELIST.length ) {
+        whitelist = mod.killWhitelistCache();
+
+        _.forEach(PLAYER_WHITELIST, function(playerName) {
+            whitelist[playerName.toLowerCase()] = true;
+        });
+    }
+};
+
 const NPC = {
     ["Source Keeper"]: true,
     ["Invader"]: true,
@@ -9,100 +106,3 @@ const CONST = {
     NEUTRAL: 1,
     NPC_SCORE: -200,
 };
-
-const mod = {
-    name: 'reputation',
-    myName: () => _.chain(Game.rooms).map('controller').flatten().filter('my').map('owner.username').first().value(),
-    isNPC: username => NPC[username] === true,
-    npcOwner: creep => creep.owner && mod.isNPC(creep.owner.username),
-    isAlly: username => mod.score(username) >= CONST.ALLY,
-    notAlly: username => !mod.isAlly(username),
-    allyOwner: creep => creep.owner && mod.isAlly(creep.owner.username),
-    isHostile: username => mod.score(username) < CONST.NEUTRAL,
-    notHostile: username => !mod.isHostile(username),
-    hostileOwner: creep => creep.owner && mod.isHostile(creep.owner.username),
-    whitelist: () => mod.cache('whitelist'),
-    score: username => {
-        const reps = mod.cache('score');
-        if( username === undefined ) {
-            return reps;
-        }
-        const name = username && username.toLowerCase();
-        if( reps[name] ) {
-            return reps[name];
-        } else {
-            return reps[name] = 0;
-        }
-    },
-    setScore: (username, score) => {
-        const name = username && username.toLowerCase();
-        mod.score()[name] = score;
-        mod.playerMemory(name).score = score;
-    },
-
-    flush: () => {
-        mod._loadWhitelist();
-        mod._loadScore();
-    },
-    cache: table => Task.cache(mod.name, table),
-    killScoreCache: () => {
-        Task.clearCache(mod.name, 'score');
-        return mod.score();
-    },
-    killWhitelistCache: () => {
-        Task.clearCache(mod.name, 'score');
-        Task.clearCache(mod.name, 'whitelist');
-        return mod.whitelist();
-    },
-    memory: table => Task.memory(mod.name, table),
-    playerMemory: username => {
-        const playerMemory = mod.memory('players');
-        const name = username && username.toLowerCase();
-        if( playerMemory[name] ) {
-            return playerMemory[name];
-        } else {
-            return playerMemory[name] = {};
-        }
-    },
-
-    _loadScore: () => {
-        const etc = mod.cache('etc');
-        const playerMemory = mod.memory('players');
-        const whitelist = mod.whitelist();
-        let score = mod.score();
-        if( _.keys(playerMemory).length + _.keys(whitelist).length
-                !== _.keys(score).length + etc.whitelistRepUnion) {
-            score = mod.killScoreCache();
-            for( const n in NPC ) {
-                score[n] = CONST.NPC_SCORE;
-            }
-            _.keys(whitelist).forEach(function(player) {
-                score[player] = CONST.WHITELIST_SCORE;
-            });
-
-            etc.whitelistRepUnion = 0;
-            _.reduce(playerMemory, function(list, player, name) {
-                if( typeof player.score === "number" ) {
-                    if( whitelist[name] ) {
-                        etc.whitelistRepUnion++;
-                    }
-                    list[name] = player.score;
-                }
-                return list;
-            }, score);
-    
-            mod.setScore(mod.myName(), CONST.MY_SCORE);
-        }
-    },
-    _loadWhitelist: () => {
-        let whitelist = mod.whitelist();
-        if( _.keys(whitelist).length !== PLAYER_WHITELIST.length ) {
-            whitelist = mod.killWhitelistCache();
-
-            _.forEach(PLAYER_WHITELIST, function(playerName) {
-                whitelist[playerName.toLowerCase()] = true;
-            });
-        }
-    },
-};
-module.exports = mod;

--- a/task.reserve.js
+++ b/task.reserve.js
@@ -1,5 +1,5 @@
 // This task will react on exploit, reserve and remotemine flags, sending a reserving creep to the flags position.
-let mod = {};
+let mod = new Task('reserve');
 module.exports = mod;
 mod.name = 'reserve';
 mod.creep = {
@@ -14,8 +14,6 @@ mod.creep = {
         behaviour: "claimer"
     },
 };
-// hook into events
-mod.register = () => {};
 // for each flag
 mod.handleFlagFound = flag => {
     // if it is a reserve, exploit or remote mine flag

--- a/task.robbing.js
+++ b/task.robbing.js
@@ -1,9 +1,7 @@
 // This task will react on robbing flags (invade/rob or red/yellow), sending 2 creeps to rob that room
-let mod = {};
+let mod = new Task('robbing');
 module.exports = mod;
 mod.name = 'robbing';
-// hook into events
-mod.register = () => {};
 // for each flag
 mod.handleFlagFound = flag => {
     // if it is a robbing flag


### PR DESCRIPTION
Turns all the tasks into an instance of the Task class. Similar to how actions are.

I'm a little worried installing tasks may be broken (specifically custom/internal ones).

In any of the `task.*` files, if you want to extend (not override) one of the instance methods defined in Task.js, I believe `super.method()` should work.