### PR TITLE
refactor/repairNearby - separate repairNearby and buildNearby

### DIFF
--- a/creep.js
+++ b/creep.js
@@ -262,15 +262,13 @@ mod.extend = function(){
     Creep.prototype.buildNearby = function() {
         // enable remote haulers to build their own roads and containers
         if (!global.REMOTE_HAULER.DRIVE_BY_BUILDING || !this.data || this.data.creepType !== 'remoteHauler') return;
-        // only search in a range of 1 to save cpu
-        let nearby = this.pos.findInRange(this.room.myConstructionSites, global.REMOTE_HAULER.DRIVE_BY_BUILD_RANGE, {filter: (site) =>{
-            return site.my && global.REMOTE_HAULER.DRIVE_BY_BUILD_ALL ||
-                (site.structureType === STRUCTURE_CONTAINER ||
-                site.structureType === STRUCTURE_ROAD);
-        }});
-        if( nearby && nearby.length ){
-            if( global.DEBUG && global.TRACE ) trace('Creep', {creepName:this.name, Action:'building', Creep:'buildNearby'}, nearby[0].pos);
-            this.build(nearby[0]);
+        const buildTarget = _(this.pos.findInRange(FIND_MY_CONSTRUCTION_SITES, global.REMOTE_HAULER.DRIVE_BY_BUILD_RANGE))
+            .find(s => global.REMOTE_HAULER.DRIVE_BY_BUILD_ALL ||
+                          (s.structureType === STRUCTURE_CONTAINER ||
+                           s.structureType === STRUCTURE_ROAD));
+        if (buildTarget) {
+            if( global.DEBUG && global.TRACE ) trace('Creep', {creepName:this.name, Action:'building', Creep:'buildNearby'}, buildTarget.pos);
+            this.build(buildTarget);
         } else {
             if( global.DEBUG && global.TRACE ) trace('Creep', {creepName:this.name, Action:'building', Creep:'buildNearby'}, 'not building');
         }

--- a/creep.js
+++ b/creep.js
@@ -250,7 +250,7 @@ mod.extend = function(){
         // if it has energy and a work part, remoteMiners do repairs once the source is exhausted.
         if(this.carry.energy > 0 && this.hasActiveBodyparts(WORK)) {
             const repairRange = this.data && this.data.creepType === 'remoteHauler' ? global.REMOTE_HAULER.DRIVE_BY_REPAIR_RANGE : global.DRIVE_BY_REPAIR_RANGE;
-            const repairTarget = _(this.pos.findInRange(FIND_STRUCTURES, repairRange)).filter(s => Room.shouldRepair(this.room, s)).first();
+            const repairTarget = _(this.pos.findInRange(FIND_STRUCTURES, repairRange)).find(s => Room.shouldRepair(this.room, s));
             if (repairTarget) {
                 if( global.DEBUG && global.TRACE ) trace('Creep', {creepName:this.name, Action:'repairing', Creep:'repairNearby'}, repairTarget.pos);
                 this.repair(repairTarget);

--- a/creep.js
+++ b/creep.js
@@ -249,11 +249,11 @@ mod.extend = function(){
         if (this.room.controller && this.room.controller.owner && !(this.room.my || this.room.reserved || this.room.ally)) return;
         // if it has energy and a work part, remoteMiners do repairs once the source is exhausted.
         if(this.carry.energy > 0 && this.hasActiveBodyparts(WORK)) {
-            const repairRange = this.data && this.data.creepType === 'remoteHauler' ? REMOTE_HAULER.DRIVE_BY_REPAIR_RANGE : DRIVE_BY_REPAIR_RANGE;
-            const nearby = _(this.pos.findInRange(FIND_STRUCTURES, repairRange)).filter(s => Room.shouldRepair(this.room, s));
-            if (nearby && nearby.length) {
-                if( global.DEBUG && global.TRACE ) trace('Creep', {creepName:this.name, Action:'repairing', Creep:'repairNearby'}, nearby[0].pos);
-                this.repair(nearby[0]);
+            const repairRange = this.data && this.data.creepType === 'remoteHauler' ? global.REMOTE_HAULER.DRIVE_BY_REPAIR_RANGE : global.DRIVE_BY_REPAIR_RANGE;
+            const repairTarget = _(this.pos.findInRange(FIND_STRUCTURES, repairRange)).filter(s => Room.shouldRepair(this.room, s)).first();
+            if (repairTarget) {
+                if( global.DEBUG && global.TRACE ) trace('Creep', {creepName:this.name, Action:'repairing', Creep:'repairNearby'}, repairTarget.pos);
+                this.repair(repairTarget);
             }
         } else {
             if( global.DEBUG && global.TRACE ) trace('Creep', {creepName:this.name, pos:this.pos, Action:'repairing', Creep:'repairNearby'}, 'not repairing');

--- a/room.js
+++ b/room.js
@@ -1260,9 +1260,9 @@ mod.shouldRepair = function(room, structure) {
         // is not at 100%
         structure.hits < structure.hitsMax &&
         // not owned room or hits below RCL repair limit
-        ( !room.my || structure.hits < MAX_REPAIR_LIMIT[room.controller.level] || structure.hits < (LIMIT_URGENT_REPAIRING + (2*DECAY_AMOUNT[structure.structureType] || 0))) &&
+        ( !room.my || structure.hits < global.MAX_REPAIR_LIMIT[room.controller.level] || structure.hits < (global.LIMIT_URGENT_REPAIRING + (2*global.DECAY_AMOUNT[structure.structureType] || 0))) &&
         // not decayable or below threshold
-        ( !DECAYABLES.includes(structure.structureType) || (structure.hitsMax - structure.hits) > GAP_REPAIR_DECAYABLE ) &&
+        ( !DECAYABLES.includes(structure.structureType) || (structure.hitsMax - structure.hits) > global.GAP_REPAIR_DECAYABLE ) &&
         // not pavement art
         ( Memory.pavementArt[room.name] === undefined || Memory.pavementArt[room.name].indexOf('x'+structure.pos.x+'y'+structure.pos.y+'x') < 0 ) &&
         // not flagged for removal

--- a/room.js
+++ b/room.js
@@ -63,7 +63,7 @@ mod.extend = function(){
                         let that = this;
                         this._repairable = _.sortBy(
                             that.all.filter(
-                                structure => Room.shouldRepair(that.room, structure);
+                                structure => Room.shouldRepair(that.room, structure)
                             ),
                             'hits'
                         );

--- a/room.js
+++ b/room.js
@@ -63,18 +63,7 @@ mod.extend = function(){
                         let that = this;
                         this._repairable = _.sortBy(
                             that.all.filter(
-                                structure => (
-                                    // is not at 100%
-                                    structure.hits < structure.hitsMax &&
-                                    // not owned room or hits below RCL repair limit
-                                    ( !that.room.my || structure.hits < MAX_REPAIR_LIMIT[that.room.controller.level] || structure.hits < (LIMIT_URGENT_REPAIRING + (2*DECAY_AMOUNT[structure.structureType] || 0))) &&
-                                    // not decayable or below threshold
-                                    ( !DECAYABLES.includes(structure.structureType) || (structure.hitsMax - structure.hits) > GAP_REPAIR_DECAYABLE ) &&
-                                    // not pavement art
-                                    ( Memory.pavementArt[that.room.name] === undefined || Memory.pavementArt[that.room.name].indexOf('x'+structure.pos.x+'y'+structure.pos.y+'x') < 0 ) &&
-                                    // not flagged for removal
-                                    ( !FlagDir.list.some(f => f.roomName == structure.pos.roomName && f.color == COLOR_ORANGE && f.x == structure.pos.x && f.y == structure.pos.y) )
-                                )
+                                structure => Room.shouldRepair(that.room, structure);
                             ),
                             'hits'
                         );
@@ -1266,3 +1255,17 @@ mod.fieldsInRange = function(args) {
     let maxY = Math.min(...plusRangeY);
     return Room.validFields(args.roomName, minX, maxX, minY, maxY, args.checkWalkable, args.where);
 };
+mod.shouldRepair = function(room, structure) {
+    return (
+        // is not at 100%
+        structure.hits < structure.hitsMax &&
+        // not owned room or hits below RCL repair limit
+        ( !room.my || structure.hits < MAX_REPAIR_LIMIT[room.controller.level] || structure.hits < (LIMIT_URGENT_REPAIRING + (2*DECAY_AMOUNT[structure.structureType] || 0))) &&
+        // not decayable or below threshold
+        ( !DECAYABLES.includes(structure.structureType) || (structure.hitsMax - structure.hits) > GAP_REPAIR_DECAYABLE ) &&
+        // not pavement art
+        ( Memory.pavementArt[room.name] === undefined || Memory.pavementArt[room.name].indexOf('x'+structure.pos.x+'y'+structure.pos.y+'x') < 0 ) &&
+        // not flagged for removal
+        ( !FlagDir.list.some(f => f.roomName == structure.pos.roomName && f.color == COLOR_ORANGE && f.x == structure.pos.x && f.y == structure.pos.y) )
+    );
+}


### PR DESCRIPTION
Also, improve the efficiency of both by focusing only on the structures in range rather than the cost of looking at all repairable/buildable structures in the room.

Usage/call of repairNearby was reduced from ~ 0.6 to ~0.3