### PR TITLE
hotfix/robbingNoPrivateers

### DIFF
--- a/room.js
+++ b/room.js
@@ -381,7 +381,7 @@ mod.extend = function(){
                         let that = this;
                         let adjacent, ownNeighbor, room, mult;
 
-                        let flagEntries = FlagDir.filter([FLAG_COLOR.invade.robbing, FLAG_COLOR.invade.exploit]);
+                        let flagEntries = FlagDir.filter(FLAG_COLOR.invade.exploit);
                         let countOwn = roomName => {
                             if( roomName == that.name ) return;
                             if( Room.isMine(roomName) ) ownNeighbor++;


### PR DESCRIPTION
This resolves #1199
stop privateers from spawning on adjacent robbing rooms, robbing flag is no longer considered when determining privateerMaxWeight