### PR TITLE
feature/defineTaskSpawnRoom - define room creeps should spawn from

### DIFF
--- a/task.js
+++ b/task.js
@@ -112,7 +112,7 @@ mod.spawn = (creepDefinition, destiny, roomParams, onQueued) => {
     const targetMem = Memory.rooms[roomParams.targetRoom];
     let room;
     if (targetMem && targetMem.spawn) {
-        const spawnRoomName = typeof targetMem.spawn === 'string' ? targetMem.spawn : targetMem.spawn[params.creepType];
+        const spawnRoomName = typeof targetMem.spawn === 'string' ? targetMem.spawn : targetMem.spawn[creepDefinition.name];
         room = Game.rooms[spawnRoomName];
     }
     // get nearest room

--- a/task.js
+++ b/task.js
@@ -109,9 +109,15 @@ mod.clearCache = (task, s) => {
 // destiny: { task, targetName }
 // roomParams: { targetRoom, minRCL = 0, maxRange = Infinity, minEnergyAvailable = 0, minEnergyCapacity = 0, callBack = null, allowTargetRoom = false, rangeRclRatio = 3, rangeQueueRatio = 51 }
 mod.spawn = (creepDefinition, destiny, roomParams, onQueued) => {
+    const targetMem = Memory.rooms[roomParams.targetRoom];
+    let room;
+    if (targetMem && targetMem.spawn) {
+        const spawnRoomName = typeof targetMem.spawn === 'string' ? targetMem.spawn : targetMem.spawn[params.creepType];
+        room = Game.rooms[spawnRoomName];
+    }
     // get nearest room
-    let room = roomParams.explicit ? Game.rooms[roomParams.explicit] : Room.findSpawnRoom(roomParams);
-    if( !room ) return null;
+    if (!room) room = roomParams.explicit ? Game.rooms[roomParams.explicit] : Room.findSpawnRoom(roomParams);
+    if (!room) return null;
     // define new creep
     if(!destiny) destiny = {};
     if(!destiny.room && roomParams.targetRoom) destiny.room = roomParams.targetRoom;


### PR DESCRIPTION
Only works for task based spawning, but you can define which room you want creeps to spawn from using
`Memory.rooms[<targetRoomName>].spawnRoom`
set it to a roomName eg. 'W5N5' to spawn all creeps from that room,
or define by creepType eg.
```
{ 'guard': 'W1N1',
'remoteMiner': 'W2N2'
}
```