### PR TITLE
hotfix/defenseMemory - clean up memory in tasks.defense

### DIFF
--- a/room.defense.js
+++ b/room.defense.js
@@ -1,7 +1,7 @@
 const mod = {};
 module.exports = mod;
 mod.analyzeRoom = function(room) {
-    if (room.hostiles.length > 0) room.processInvaders();
+    if (room.hostiles.length || (room.memory.hostileIds && room.memory.hostileIds.length)) room.processInvaders();
 };
 const triggerNewInvaders = creep => {
     // create notification


### PR DESCRIPTION
Fix bug that was likely preventing Memory.tasks.defense from being cleaned up properly

hopefully this resolves https://github.com/ScreepsOCS/screeps.behaviour-action-pattern/issues/924 I have merged it into an active branch and will check again in 24 hrs