### PR TITLE
hotfix/determinatedStorage - miners don't try to work on storage/terminal

### DIFF
--- a/creep.action.mining.js
+++ b/creep.action.mining.js
@@ -32,7 +32,7 @@ action.determineSpot = function(creep, source) {
             invalid.push(entry.determinatedSpot);
     };
     _.forEach(Memory.population, findInvalid);
-    const containerSpot = (source.container && source.container.pos.isNearTo(source)
+    const containerSpot = (source.container && source.container.structureType === STRUCTURE_CONTAINER && source.container.pos.isNearTo(source)
         && !_.some(invalid,{x:source.container.pos.x, y:source.container.pos.y})) ? source.container.pos : null;
     let spots = [];
     let args;


### PR DESCRIPTION
This prevents miners from setting their determinatedSpot to the location of the room's storage or terminal if the source uses them as its container.